### PR TITLE
Tweak justfile recipes

### DIFF
--- a/justfile
+++ b/justfile
@@ -26,13 +26,13 @@ forbid:
   ./bin/forbid
 
 run *args:
-  cargo run -- --{{args}}
+  cargo run -- {{args}}
 
 readme:
-  cargo run -- --in-place --path README.md
+  cargo run -- README.md --in-place
 
-test:
-  cargo test
+test *args:
+  cargo test --all-targets {{args}}
 
 usage:
   cargo run -- --help | pbcopy


### PR DESCRIPTION
- `test` now takes arguments, and uses --all-targets by default
- `readme` no longer needs a `--path` option
- `run` takes arguments without a `--` prefix