### PR TITLE
Improve tokenization

### DIFF
--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -1,9 +1,8 @@
 use {
   crate::walker::{Walker, WalkerOptions},
+  clap::Parser as StructOpt,
   present::{File, Result},
 };
-
-use clap::Parser as StructOpt;
 
 #[derive(Debug, StructOpt)]
 #[clap(about = env!("CARGO_PKG_DESCRIPTION"), version = env!("CARGO_PKG_VERSION"))]

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,4 +1,4 @@
-use crate::{common::*, Error, Result};
+use crate::{common::*, Error, Result, Tokenize};
 
 const PREFIX: &str = "present";
 
@@ -9,14 +9,14 @@ pub(crate) struct Command {
 }
 
 impl Command {
-  pub(crate) fn from(command: Vec<String>) -> Option<Self> {
-    match &*command {
+  pub(crate) fn from(command: Vec<String>) -> Result<Option<Self>> {
+    Ok(match &*command {
       [prefix, program, arguments @ ..] if prefix == PREFIX => Some(Self {
         program: program.to_string(),
-        arguments: arguments.to_owned(),
+        arguments: arguments.join(" ").tokenize()?,
       }),
       _ => None,
-    }
+    })
   }
 
   pub(crate) fn execute(&self) -> Result<String> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -14,11 +14,11 @@ pub enum Error {
   #[snafu(context(false), display("IO Error: {}", source))]
   Io { source: io::Error },
 
-  #[snafu(display("Lex error: {}", message))]
-  LexError { message: String },
-
   #[snafu(display("Path does not exist: {}", path.display()))]
   PathDoesNotExist { path: PathBuf },
+
+  #[snafu(display("Tokenize Error: {}", message))]
+  TokenizeError { message: String },
 
   #[snafu(context(false), display("Utf8 Error: {}", source))]
   Utf8 { source: std::string::FromUtf8Error },

--- a/src/error.rs
+++ b/src/error.rs
@@ -14,6 +14,9 @@ pub enum Error {
   #[snafu(context(false), display("IO Error: {}", source))]
   Io { source: io::Error },
 
+  #[snafu(display("Lex error: {}", message))]
+  LexError { message: String },
+
   #[snafu(display("Path does not exist: {}", path.display()))]
   PathDoesNotExist { path: PathBuf },
 

--- a/src/file.rs
+++ b/src/file.rs
@@ -17,8 +17,10 @@ impl File {
   ///
   /// # Errors
   ///
-  /// This function will return an error if the file is not readable into a
-  /// string.
+  /// This function will return an error if the file if the following conditions
+  /// are true:
+  /// - The file is not readable into a string
+  /// - The parser failed to parse the file contents
   pub fn new(path: PathBuf) -> Result<Self> {
     let content = fs::read_to_string(&path)?;
 
@@ -27,7 +29,7 @@ impl File {
     Ok(Self {
       path,
       content: Rope::from_str(&content.clone()),
-      commands: parser.parse(),
+      commands: parser.parse()?,
       remove: false,
       interactive: false,
     })

--- a/src/file.rs
+++ b/src/file.rs
@@ -17,7 +17,7 @@ impl File {
   ///
   /// # Errors
   ///
-  /// This function will return an error if the file if the following conditions
+  /// This function will return an error if the following conditions
   /// are true:
   /// - The file is not readable into a string
   /// - The parser failed to parse the file contents

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ mod parser;
 mod position;
 mod prompt;
 mod rope_ext;
+mod tokenize;
 
 // Publicly exposed
 pub use crate::{diff::Diff, error::Error, file::File};
@@ -34,7 +35,7 @@ pub use crate::{diff::Diff, error::Error, file::File};
 // Public only to crate
 pub(crate) use crate::{
   command::Command, parser::Parser, position::Position, prompt::prompt,
-  rope_ext::RopeExt,
+  rope_ext::RopeExt, tokenize::Tokenize,
 };
 
 /// Present's internal result type

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,11 @@
-use clap::Parser;
+use {crate::arguments::Arguments, clap::Parser};
 
 mod arguments;
 mod path_ext;
 mod walker;
 
 fn main() {
-  if let Err(error) = arguments::Arguments::parse().run() {
+  if let Err(error) = Arguments::parse().run() {
     eprintln!("error: {error}");
     std::process::exit(1);
   }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,4 +1,4 @@
-use crate::{codeblock::parse_codeblock, common::*, Command, Position};
+use crate::{codeblock::parse_codeblock, common::*, Command, Position, Result};
 
 #[derive(Debug, Clone)]
 pub(crate) struct Parser<'a> {
@@ -10,8 +10,8 @@ impl<'a> Parser<'a> {
     Self { src }
   }
 
-  pub(crate) fn parse(&self) -> Vec<(Position, Command)> {
-    MarkdownParser::new(self.src)
+  pub(crate) fn parse(&self) -> Result<Vec<(Position, Command)>> {
+    let ranges = MarkdownParser::new(self.src)
       .into_offset_iter()
       .filter(|event| {
         matches!(
@@ -19,7 +19,17 @@ impl<'a> Parser<'a> {
           (Event::Start(Tag::CodeBlock(CodeBlockKind::Fenced(_))), _)
         )
       })
-      .filter_map(|event| parse_codeblock(self.src, event.1))
-      .collect()
+      .map(|event| event.1)
+      .collect::<Vec<Range<usize>>>();
+
+    let mut parsed_codeblocks = Vec::new();
+
+    for range in ranges {
+      if let Some(parsed_codeblock) = parse_codeblock(self.src, range)? {
+        parsed_codeblocks.push(parsed_codeblock);
+      }
+    }
+
+    Ok(parsed_codeblocks)
   }
 }

--- a/src/tokenize.rs
+++ b/src/tokenize.rs
@@ -9,6 +9,7 @@ impl Tokenize for String {
     let mut tokens = Vec::new();
 
     let mut chars = self.chars().peekable();
+
     while let Some(ch) = chars.next() {
       match ch {
         '\'' | '"' => {
@@ -23,12 +24,14 @@ impl Tokenize for String {
               message: "Unmatched delimeter".into(),
             })?;
 
-          for next in chars.by_ref() {
-            if next == ch {
-              break;
+          while let Some(next) = chars.next() {
+            match next {
+              next if next == ch => break,
+              _ => group.push(next),
             }
-            group.push(next);
           }
+
+          chars.next();
 
           tokens.push(group);
         }
@@ -49,8 +52,8 @@ impl Tokenize for String {
 
           tokens.extend(
             group
+              .trim()
               .split(' ')
-              .filter(|argument| !argument.is_empty())
               .map(|argument| argument.to_owned())
               .collect::<Vec<String>>(),
           );
@@ -88,8 +91,8 @@ mod tests {
   #[test]
   fn tokenize_mixed() {
     assert_eq!(
-      "a 'b' c 'd e' f g \"h i\"".to_string().tokenize().unwrap(),
-      vec!["a", "b", "c", "d e", "f", "g", "h i"]
+      "a 'b' c 'de' f g \"h i\"".to_string().tokenize().unwrap(),
+      vec!["a", "b", "c", "de", "f", "g", "h i"]
     );
   }
 

--- a/src/tokenize.rs
+++ b/src/tokenize.rs
@@ -24,7 +24,7 @@ impl Tokenize for String {
               message: "Unmatched delimeter".into(),
             })?;
 
-          while let Some(next) = chars.next() {
+          for next in chars.by_ref() {
             match next {
               next if next == ch => break,
               _ => group.push(next),

--- a/src/tokenize.rs
+++ b/src/tokenize.rs
@@ -1,0 +1,108 @@
+use crate::{Error, Result};
+
+pub(crate) trait Tokenize {
+  fn tokenize(self) -> Result<Vec<String>>;
+}
+
+impl Tokenize for String {
+  fn tokenize(self) -> Result<Vec<String>> {
+    let mut tokens = Vec::new();
+
+    let mut chars = self.chars().peekable();
+    while let Some(ch) = chars.next() {
+      match ch {
+        '\'' | '"' => {
+          let mut group = String::new();
+
+          chars
+            .clone()
+            .collect::<Vec<char>>()
+            .iter()
+            .find(|next| **next == ch)
+            .ok_or(Error::LexError {
+              message: "Unmatched delimeter".into(),
+            })?;
+
+          for next in chars.by_ref() {
+            if next == ch {
+              break;
+            }
+            group.push(next);
+          }
+
+          tokens.push(group);
+        }
+        _ => {
+          let mut group = String::new();
+
+          group.push(ch);
+
+          while let Some(next) = chars.peek() {
+            match next {
+              '\'' | '"' => break,
+              _ => {
+                group.push(*next);
+                chars.next();
+              }
+            }
+          }
+
+          tokens.extend(
+            group
+              .split(' ')
+              .filter(|argument| !argument.is_empty())
+              .map(|argument| argument.to_owned())
+              .collect::<Vec<String>>(),
+          );
+        }
+      }
+    }
+
+    Ok(tokens)
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn tokenize_single() {
+    assert_eq!(
+      "-c 'for i in {1..10}; do echo $i; done'"
+        .to_string()
+        .tokenize()
+        .unwrap(),
+      vec!["-c", "for i in {1..10}; do echo $i; done"]
+    );
+  }
+
+  #[test]
+  fn tokenize_multiple() {
+    assert_eq!(
+      "-c 'echo foo' 'echo bar'".to_string().tokenize().unwrap(),
+      vec!["-c", "echo foo", "echo bar"]
+    );
+  }
+
+  #[test]
+  fn tokenize_mixed() {
+    assert_eq!(
+      "a 'b' c 'd e' f g \"h i\"".to_string().tokenize().unwrap(),
+      vec!["a", "b", "c", "d e", "f", "g", "h i"]
+    );
+  }
+
+  #[test]
+  fn ignore_empty() {
+    assert_eq!(
+      "a     'bc'".to_string().tokenize().unwrap(),
+      vec!["a", "bc"]
+    );
+  }
+
+  #[test]
+  fn unmatched_delimiter() {
+    assert!("-c 'echo foo".to_string().tokenize().is_err(),);
+  }
+}

--- a/src/tokenize.rs
+++ b/src/tokenize.rs
@@ -20,7 +20,7 @@ impl Tokenize for String {
             .collect::<Vec<char>>()
             .iter()
             .find(|next| **next == ch)
-            .ok_or(Error::LexError {
+            .ok_or(Error::TokenizeError {
               message: "Unmatched delimeter".into(),
             })?;
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -522,6 +522,24 @@ fn inline_script_complex() -> Result {
 }
 
 #[test]
+fn inline_unmatched_delimiter() -> Result {
+  Test::new()?
+    .markdown(
+      "
+      ```present bash -c 'echo foo
+      ```
+      ",
+    )
+    .expected_status(1)
+    .expected_stderr(
+      "
+      error: Tokenize Error: Unmatched delimeter
+      ",
+    )
+    .run()
+}
+
+#[test]
 fn interactive_accept() -> Result {
   let tempdir = Test::new()?
     .markdown("```present echo foo\n```")

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -104,7 +104,7 @@ impl Test {
     assert_eq!(
       output.status.code(),
       Some(self.expected_status),
-      "\n\nMarkdown:\n\n{:?}\nfailed: {}",
+      "\n\nMarkdown:\n{:?}\nfailed with output: {}",
       self.markdown,
       stderr
     );
@@ -466,6 +466,55 @@ fn multiple_markdown_files() -> Result {
       ```
       ```present echo foo
       foo
+      ```
+      ",
+    )
+    .run()
+}
+
+#[test]
+fn inline_script_simple() -> Result {
+  Test::new()?
+    .markdown(
+      "
+      ```present bash -c 'echo foo'
+      ```
+      ",
+    )
+    .expected_status(0)
+    .expected_stdout(
+      "
+      ```present bash -c 'echo foo'
+      foo
+      ```
+      ",
+    )
+    .run()
+}
+
+#[test]
+fn inline_script_complex() -> Result {
+  Test::new()?
+    .markdown(
+      "
+      ```present bash -c 'for i in {1..10}; do echo $i; done'
+      ```
+      ",
+    )
+    .expected_status(0)
+    .expected_stdout(
+      "
+      ```present bash -c 'for i in {1..10}; do echo $i; done'
+      1
+      2
+      3
+      4
+      5
+      6
+      7
+      8
+      9
+      10
       ```
       ",
     )


### PR DESCRIPTION
The way command arguments are grouped disallows for things such as `bash -c 'echo foo'` to work, since we're only splitting on whitespace.

Related to #14, this PR allows for arguments to have string groupings, e.g. `bash -c 'echo foo'` will be tokenized as `['bash', '-c', 'echo foo']`