### PR TITLE
Add `--verbose` flag

### DIFF
--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -17,6 +17,8 @@ pub(crate) struct Arguments {
   pub(crate) pretty: bool,
   #[clap(long, help = "Remove commands within markdown documents.")]
   pub(crate) remove: bool,
+  #[clap(short, long, help = "Show output of commands being executed.")]
+  pub(crate) verbose: bool,
 }
 
 impl Arguments {
@@ -28,7 +30,7 @@ impl Arguments {
           .remove(self.remove)
           .interactive(self.interactive);
 
-        file.present()?;
+        file.present(self.verbose)?;
 
         match self.in_place {
           true => file.save()?,

--- a/src/command.rs
+++ b/src/command.rs
@@ -19,7 +19,7 @@ impl Command {
     })
   }
 
-  pub(crate) fn execute(&self) -> Result<String> {
+  pub(crate) fn execute(&self, verbose: bool) -> Result<String> {
     let output = process::Command::new(&self.program)
       .args(&self.arguments)
       .output();
@@ -40,6 +40,12 @@ impl Command {
       });
     }
 
-    Ok(String::from_utf8(output.stdout)?)
+    let stdout_str = String::from_utf8(output.stdout)?;
+    if verbose {
+      println!("> {} {}", &self.program, self.arguments.join(" "));
+      println!("{}", &stdout_str);
+    }
+
+    Ok(stdout_str)
   }
 }

--- a/src/file.rs
+++ b/src/file.rs
@@ -71,10 +71,13 @@ impl File {
   ///
   /// The [`Diff`]s are returned as results. If the command fails, the item will
   /// be of the `Err` kind.
-  pub fn diffs(&self) -> impl Iterator<Item = Result<Diff>> + '_ {
-    self.codeblocks.iter().map(|codeblock| {
+  pub fn diffs(
+    &self,
+    verbose: bool,
+  ) -> impl Iterator<Item = Result<Diff>> + '_ {
+    self.codeblocks.iter().map(move |codeblock| {
       Ok(Diff {
-        content: codeblock.command.execute()?,
+        content: codeblock.command.execute(verbose)?,
         range: match self.remove {
           // Replace the entire codeblock with `stdout`
           true => {
@@ -93,10 +96,10 @@ impl File {
   ///
   /// If [`interactive`](File::interactive) is set to `true`, the user will be
   /// asked if they want to apply the change for each diff.
-  pub fn present(&mut self) -> Result {
+  pub fn present(&mut self, verbose: bool) -> Result {
     let mut offset: isize = 0;
 
-    let diffs = self.diffs().collect::<Result<Vec<Diff>>>()?;
+    let diffs = self.diffs(verbose).collect::<Result<Vec<Diff>>>()?;
 
     for mut diff in diffs {
       let prev = self.content.len_bytes();


### PR DESCRIPTION
It seems to be hard to both get a streaming output to your terminal AND capture the stdout of the running command.

This is a PoC, it just shows the invoked command and prints the captured output to the terminal. Might wanna show WHAT block in the markdown file it originated from.

Fixes #35.